### PR TITLE
Add config.cpp for device and URL customization

### DIFF
--- a/config.cpp
+++ b/config.cpp
@@ -1,0 +1,14 @@
+#include <QString>
+#include "config.h"
+
+const QString Config::updaterUrl = "https://github.com/pine64/pinecil-firmware-updater/releases/latest";
+
+const QString Config::deviceName = "Pinecil";
+const QString Config::firmwareInfo = "http://pinecil.pine64.org/updater/info.json";
+const QString Config::firmwareFolder = "http://pinecil.pine64.org/updater/firmwares/";
+
+const int Config::dfuVID = 0x0483;
+const int Config::dfuPID = 0xdf11;
+const int Config::dfuAlternate = 0;
+const int Config::dfuseAddress = 0x08000000;
+

--- a/config.h
+++ b/config.h
@@ -1,0 +1,19 @@
+#ifndef CONFIG_H
+#define CONFIG_H
+
+class Config
+{
+    public:
+        static const QString updaterUrl;
+
+        static const QString deviceName;
+        static const QString firmwareInfo;
+        static const QString firmwareFolder;
+
+        static const int dfuVID;
+        static const int dfuPID;
+        static const int dfuAlternate;
+        static const int dfuseAddress;
+};
+
+#endif /* CONFIG_H */

--- a/flashingthread.cpp
+++ b/flashingthread.cpp
@@ -1,4 +1,5 @@
 #include "flashingthread.h"
+#include "config.h"
 
 #include <QCoreApplication>
 #include <QProcess>
@@ -12,9 +13,9 @@ void FlashingThread::run()
         QProcess zadic;
         QStringList zadicArgs;
         zadicArgs.append("--vid");
-        zadicArgs.append("0x28E9");
+        zadicArgs.append(QString("0x%1").arg(Config::dfuVID, 4, 16, QChar('0')));
         zadicArgs.append("--pid");
-        zadicArgs.append("0x0189");
+        zadicArgs.append(QString("0x%1").arg(Config::dfuPID, 4, 16, QChar('0')));
         zadicArgs.append("--noprompt");
         connect(&zadic, &QProcess::readyReadStandardOutput, [this, &zadic] {
             emit this->consoleData(zadic.readAllStandardOutput());
@@ -39,13 +40,13 @@ void FlashingThread::run()
     QProcess dfuUtil;
     QStringList dfuUtilArgs;
     dfuUtilArgs.append("-d");
-    dfuUtilArgs.append("28e9:0189");
+    dfuUtilArgs.append(QString("%1").arg(Config::dfuVID, 4, 16, QChar('0')) + QString(":%1").arg(Config::dfuPID, 4, 16, QChar('0')));
     dfuUtilArgs.append("-a");
-    dfuUtilArgs.append("0");
+    dfuUtilArgs.append(QString("%1").arg(Config::dfuAlternate));
     dfuUtilArgs.append("-D");
     dfuUtilArgs.append(this->firmwarePath);
     dfuUtilArgs.append("-s");
-    dfuUtilArgs.append(QString("0x08000000") + (this->massErase ? ":mass-erase:force" : ""));
+    dfuUtilArgs.append(QString("0x%1").arg(Config::dfuseAddress, 8, 16, QChar('0')) + (this->massErase ? ":mass-erase:force" : ""));
     connect(&dfuUtil, &QProcess::readyReadStandardOutput, [this, &dfuUtil] {
         emit this->consoleData(dfuUtil.readAllStandardOutput());
     });

--- a/pinecil_firmware_updater.pro
+++ b/pinecil_firmware_updater.pro
@@ -9,6 +9,7 @@ CONFIG += c++11
 #DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0
 
 SOURCES += \
+    config.cpp \
     aboutdialog.cpp \
     connectpinecildialog.cpp \
     flashingthread.cpp \
@@ -16,6 +17,7 @@ SOURCES += \
     mainwindow.cpp
 
 HEADERS += \
+    config.h \
     aboutdialog.h \
     connectpinecildialog.h \
     flashingthread.h \


### PR DESCRIPTION
At least most of the "magic numbers" and URLs are now in one small file for easy adaptation. Later looking for an ini file (via QSettings) could be considered.