### PR TITLE
Reorder member definitions to avoid compiler warning

### DIFF
--- a/flashingthread.h
+++ b/flashingthread.h
@@ -14,8 +14,8 @@ protected:
     void run();
 private:
     bool driverMissing;
-    bool massErase;
     QString firmwarePath;
+    bool massErase;
 
 signals:
     void successed();


### PR DESCRIPTION
With this it compiles without any warnings here (gcc 9.3.0).


In file included from flashingthread.cpp:1:
flashingthread.h: In constructor ‘FlashingThread::FlashingThread(QObject*, bool, QString, bool)’:
flashingthread.h:18:13: warning: ‘FlashingThread::firmwarePath’ will be initialized after [-Wreorder]
   18 |     QString firmwarePath;
      |             ^~~~~~~~~~~~
flashingthread.h:17:10: warning:   ‘bool FlashingThread::massErase’ [-Wreorder]
   17 |     bool massErase;
      |          ^~~~~~~~~
flashingthread.h:10:5: warning:   when initialized here [-Wreorder]
   10 |     FlashingThread(QObject *parent = nullptr, bool driverMissing = false, QString firmwarePath = "", bool massErase = false)
      |     ^~~~~~~~~~~~~~

